### PR TITLE
Finished methods to create and remove test teams

### DIFF
--- a/lib/collections/Teams.js
+++ b/lib/collections/Teams.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
+import { times } from 'lodash';
 
 // Defining our Posts collection
 
@@ -183,6 +184,73 @@ Meteor.methods({
             Teams.update({_id: teams[i]._id}, {$set: {destination: locations[i % numPuzzles]}});
         }
         return true;
+    },
+
+    'test.makeTeams': function (fields) {
+        if (process.env.NODE_ENV === "development" && Meteor.isServer) {
+            // This code can be run by anyone if the server is in development
+            check(fields, {
+                teams: Match.Integer
+            });
+            let teamsToCreate = fields.teams;
+
+            let usersToCreate = 5;
+            let emailVerifyOptions = {
+                $set: {
+                    "emails.0.verified": true,
+                    "updated": new Date()
+                }
+            }
+
+            times(teamsToCreate, (i) => {
+                let users = new Array(usersToCreate);
+                times(usersToCreate, (j) => {
+                    let userUnique = (i * usersToCreate) + j;
+                    users[j] = Accounts.createUser({
+                        username: `testuser${userUnique}`,
+                        password: `secure${userUnique}`,
+                        phone: '3606493000',
+                        email: `testemail${userUnique}@example.com`,
+                    });
+                    Meteor.users.update(users[j], emailVerifyOptions);
+                });
+                let team = {
+                    name: `GPH Test Team ${i}`,
+                    password: `teampassword${i}`,
+                    owner: users[0],
+                    created: new Date(),
+                    updated: new Date(),
+                    destination: '',
+                    members: users,
+                };
+                let newTeamId = Teams.insert(team, (err) => {
+                    if (err) {
+                        throw new Meteor.Error(err.reason);
+                    }
+                });
+                let teamOptions = {
+                    $set: {
+                        "teamId": newTeamId,
+                        "updated": new Date(),
+                    }
+                }
+                users.map((user) => {
+                    Meteor.users.update(user, teamOptions);
+                });
+            });
+        } else {
+            return false;
+        }
+    },
+
+    'test.removeTeams': function () {
+        if (process.env.NODE_ENV === "development" && Meteor.isServer) {
+            // I guess anyone can run this in development
+            Meteor.users.remove({username:/testuser/});
+            Teams.remove({name:/GPH Test Team/});
+        } else {
+            return false;
+        }
     }
 
 });


### PR DESCRIPTION
I am not sure if these methods are secure for production or development.

test.makeTeams creates a specified number of teams
   * Each team will have 5 registered members by default

test.removeTeams removes all teams and users created by test.makeTeams

I didn't end up using the Meteor methods for creating users and teams. I felt that making those methods work for development made them unnecessarily complicated.