### PR TITLE
Handle duplicate email in registering accounts by not storing an offi…

### DIFF
--- a/client/routes/accounts-config.jsx
+++ b/client/routes/accounts-config.jsx
@@ -17,13 +17,12 @@ Accounts.onEmailVerificationLink((token, done) => {
           console.log(err);
       } else {
           done();
-          browserHistory.push('/team');
+          browserHistory.push('/profile');
       }
   });
 });
 
-// Redirect users clicking the enrollment URL to the reset password form
-// now that we have their reset token.
+// Redirect users clicking the enrollment URL to account setup
 Accounts.onEnrollmentLink((token, done) => {
     done();
     browserHistory.push('/setup/' + token);

--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -35,27 +35,30 @@ Meteor.methods({
   findUserByToken(token) {
     check(token, String);
 
-    const user = Meteor.users.findOne({ 'services.password.reset.token': token }, {
-      fields: { name: 1 },
-    });
+    const user = Meteor.users.findOne({ 'services.password.reset.token': token });
     return user;
   },
 
   setupAccount(fields) {
     check(fields, Object);
-    const { username, password1, password2, token } = fields;
+    const { email, username, password1, password2, token } = fields;
 
     if (!Meteor.isServer) {
       return false;
     }
 
-    if (username.length < USERNAME_MIN_LENGTH) {
-      throw new Meteor.Error(400, `Username must be at least ${USERNAME_MIN_LENGTH} characters long!`);
+    const existingEmail = Accounts.findUserByEmail(email);
+    if (existingEmail) {
+      throw new Meteor.Error(400, 'Sorry that email is already in use!  This is likely because someone else bought your registration and you need to switch to using your own email address :).  If you have questions email support@greatpuzzlehunt.com');
     }
 
-    const existingUser = Accounts.findUserByUsername(username);
-    if (existingUser) {
+    const existingUsername = Accounts.findUserByUsername(username);
+    if (existingUsername) {
       throw new Meteor.Error(400, 'Sorry that username is already taken!');
+    }
+
+    if (username.length < USERNAME_MIN_LENGTH) {
+      throw new Meteor.Error(400, `Username must be at least ${USERNAME_MIN_LENGTH} characters long!`);
     }
 
     if (password1.length < PASSWORD_MIN_LENGTH) {
@@ -71,11 +74,20 @@ Meteor.methods({
     }
 
     // Set account info.
+    const emailVerified = user.email === email;
+    Accounts.addEmail(user._id, email, emailVerified);
     Accounts.setUsername(user._id, username);
     Accounts.setPassword(user._id, password1, { logout: true });
 
+    // Remove initial email field
+    Meteor.users.update(user._id, { $unset: { email: 1 }});
+
+    if (!emailVerified) {
+      Accounts.sendVerificationEmail(user._id);
+    }
+
     // Fresh login for new account
-    return true;
+    return { login: emailVerified };
   },
 
   'user.update.account': function(fields) {
@@ -99,8 +111,8 @@ Meteor.methods({
       throw new Meteor.Error(400, `Username must be at least ${USERNAME_MIN_LENGTH} characters long!`);
     }
 
-    const existingUser = Accounts.findUserByUsername(username);
-    if (existingUser && existingUser._id !== currentUser) {
+    const existingUsername = Accounts.findUserByUsername(username);
+    if (existingUsername && existingUsername._id !== currentUser) {
       throw new Meteor.Error(400, 'Sorry that username is already taken!');
     }
 

--- a/server/accounts.js
+++ b/server/accounts.js
@@ -14,11 +14,11 @@ Accounts.emailTemplates.verifyEmail = {
     html(user, url) {
         return `
 <p>Hi ${user.firstname}!</p>
-<p>Note your username is <strong>${user.username}</strong>
+<p>Your username is <strong>${user.username}</strong>
 <p>Please verify this email address by clicking <a href='${url}'>here</a>.</p>
 <br>
 <p>
-Cheers,
+Cheers,<br>
 The ${siteName} Team
 </p>`;
     }

--- a/server/webhooks/imports/register-user.js
+++ b/server/webhooks/imports/register-user.js
@@ -7,9 +7,8 @@ import googleDistanceMatrix from 'google-distance-matrix';
 export function registerUser(user, transaction) {
   const { firstname, lastname } = makeNames(user.name);
   const { email } = user;
-  const userOptions = omit(user, ['email']);
 
-  extend(userOptions, {
+  const userOptions = extend(user, {
     transactionId: transaction._id,
     updatedAt: new Date(),
     roles: ['user'],
@@ -21,6 +20,7 @@ export function registerUser(user, transaction) {
   const userId = Accounts.createUser(userOptions);
   Accounts.addEmail(userId, email, true);
   Accounts.sendEnrollmentEmail(userId);
+  Accounts.removeEmail(userId, email);
 
   // computeDistanceTraveled(userId, userOptions);
 
@@ -34,7 +34,7 @@ function computeDistanceTraveled(userId, { address, city, state, zip }) {
   googleDistanceMatrix.matrix(origins, destinations, function (err, distances) {
     const distance = distances.rows[0].elements[0].distance.value
     Meteor.users.update({ _id: userId }, { $set: { distanceTraveled: distance } });
-  })
+  });
 }
 
 export function makeNames(name) {


### PR DESCRIPTION
This handles the case where a single transaction used the same email address for multiple participants.

We create each user with the email, send the setup account email to that email and then remove the email only storing a temporary `email` field directly on the user.

On Account setup, if the email sent back matches, we verify it.  If it is different (and it is required to be different in order to finish account setup).  If it changes, we display a success message and send a new email verification link to the new email.